### PR TITLE
Add next@13 as peerDependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -22,7 +22,7 @@
     "cookie": "^0.5.0"
   },
   "peerDependencies": {
-    "next": "^10.0.8 || ^11.0 || ^12.0",
+    "next": "^10.0.8 || ^11.0 || ^12.0 || 13.0", 
     "react": "15.x || 16.x || 17.x || 18.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Considering this package only uses
 - `useRouter`
 - `NextRequest` & `NextResponse` as types,
next@13 should be allowed to be used

solves #9